### PR TITLE
Issue 12: add analysis artifacts

### DIFF
--- a/specs/issues/12/01-what-we-build.md
+++ b/specs/issues/12/01-what-we-build.md
@@ -1,0 +1,76 @@
+# Issue 12: Что строим
+
+## Problem
+
+Launcher сейчас всегда создает новую `zellij` session через сгенерированный
+`launch-layout.kdl` с одним tab и одним pane. Из-за этого:
+
+- нельзя использовать заранее настроенный именованный layout пользователя;
+- новая session стартует без привычного default UX `zellij`;
+- analysis pane становится единственной точкой входа, а вспомогательные pane
+  для логов, мониторинга и операционной работы приходится добавлять вручную.
+
+## Who Is It For
+
+Фича нужна оператору и разработчику, который запускает `ai-teamlead` в
+собственной `zellij` session и ожидает один из двух сценариев:
+
+- session стартует с его project-local или user-local layout;
+- при отсутствии кастомного layout session выглядит как обычный запуск
+  `zellij`, а не как минимальная техническая заготовка.
+
+## Feature Story
+
+Как пользователь `ai-teamlead`, я хочу задать `zellij.layout` в
+`./.ai-teamlead/settings.yml`, чтобы новая session создавалась с моим layout, а
+analysis tab добавлялся автоматически, не ломая текущий workflow и обратную
+совместимость конфига.
+
+## Use Cases
+
+1. Пользователь указывает `zellij.layout: "my-custom-layout"` и получает новую
+   session с несколькими pane или tab из своего layout, после чего туда
+   автоматически добавляется analysis tab `ai-teamlead`.
+2. Пользователь не указывает `zellij.layout`, но при первом запуске все равно
+   получает нормальную default session `zellij` c привычным UX, после чего
+   analysis tab появляется как дополнительная рабочая вкладка.
+3. Если session уже существует, `ai-teamlead` не пересоздает ее и продолжает
+   добавлять analysis tab в существующий session context.
+
+## Scope
+
+В первую версию входят:
+
+- новое опциональное поле `zellij.layout` в repo-local конфиге;
+- сохранение совместимости старых `settings.yml`, где это поле отсутствует;
+- новый launch path для случая, когда session еще не существует;
+- fallback на нормальный default UX `zellij`, если `zellij.layout` не задан;
+- отдельное добавление analysis tab после старта новой session;
+- обновление шаблона `templates/init/settings.yml`;
+- тесты на оба сценария запуска: с layout и без layout.
+
+## Non-Goals
+
+В эту задачу не входят:
+
+- поддержка отдельного типа значения для пути к `.kdl` файлу;
+- редизайн поведения для уже существующей session;
+- управление содержимым пользовательского layout или его валидация до запуска;
+- восстановление session/tab после падения `zellij`;
+- расширение project-local конфига другими режимами запуска.
+
+## Constraints
+
+- Источник конфигурации остается прежним: `./.ai-teamlead/settings.yml`.
+- Поле `zellij.layout` должно быть действительно опциональным на уровне YAML и
+  Rust-модели.
+- Analysis tab должен по-прежнему запускать `./.ai-teamlead/launch-agent.sh`
+  через сгенерированный `launch-layout.kdl`.
+- Для существующей session нельзя сломать текущий сценарий добавления tab через
+  сгенерированный layout.
+
+## Dependencies
+
+- CLI-контракт `zellij` для создания новой session с именованным layout.
+- CLI-контракт `zellij` для добавления нового tab в уже запущенную session.
+- Текущее shell-abstraction и unit-тесты в `src/zellij.rs`.

--- a/specs/issues/12/02-how-we-build.md
+++ b/specs/issues/12/02-how-we-build.md
@@ -1,0 +1,130 @@
+# Issue 12: Как строим
+
+## Approach
+
+Решение строится как точечное расширение текущего launcher-контракта без
+перестройки orchestration flow:
+
+1. Расширить `ZellijConfig` новым полем `layout: Option<String>`.
+2. Сохранить генерацию `launch-layout.kdl` для analysis pane как отдельного
+   runtime-артефакта.
+3. Разделить логику запуска новой session и логику добавления analysis tab:
+   новая session создается либо пользовательским layout, либо обычным default
+   UX `zellij`, а analysis tab подключается отдельным действием.
+4. Для уже существующей session оставить текущую модель "добавить tab через
+   generated layout".
+
+## Affected Areas
+
+- `src/config.rs`
+  модель `ZellijConfig`, десериализация и unit-тесты конфига;
+- `src/zellij.rs`
+  ветвление по состоянию session и сборка команд запуска;
+- `templates/init/settings.yml`
+  документирование нового опционального поля;
+- unit-тесты launcher'а и, при необходимости, integration smoke на реальном
+  `zellij`.
+
+## Interfaces And Data
+
+Новый конфигурационный контракт:
+
+```yaml
+zellij:
+  session_name: "ai-teamlead"
+  tab_name: "issue-analysis"
+  layout: "my-custom-layout"  # optional
+```
+
+Семантика поля:
+
+- `None`: launcher не использует bare generated layout для создания новой
+  session и должен сохранить обычный default UX `zellij`;
+- `Some(name)`: launcher создает новую session через именованный layout
+  `zellij`;
+- analysis tab во всех случаях продолжает собираться из сгенерированного
+  `launch-layout.kdl`.
+
+Ожидаемая матрица поведения:
+
+1. `session exists`
+   `zellij --session <name> --layout <generated.kdl>`
+2. `session missing` + `zellij.layout = Some(name)`
+   сначала создать session через пользовательский layout, затем добавить новый
+   analysis tab через generated layout
+3. `session missing` + `zellij.layout = None`
+   сначала создать session с нормальным built-in UX `zellij`, затем добавить
+   analysis tab через generated layout
+
+Точная CLI-форма для шага "добавить analysis tab в уже запущенную session"
+должна быть подтверждена на версии `zellij`, используемой в проекте. Из issue
+следует направление `zellij action new-tab --layout <generated.kdl>`, но в
+реализации нужно подтвердить способ адресации нужной session.
+
+## External Interfaces
+
+Внешний интерфейс только один: `zellij` CLI.
+
+Команды, которые участвуют в дизайне:
+
+- `zellij list-sessions --short`
+- `zellij --session <name> --layout <layout-name-or-generated-kdl>`
+- создание новой session без bare generated layout, чтобы сохранить default UX
+- `zellij action new-tab --layout <generated.kdl>` или эквивалентная команда
+  для живой session
+
+## Risks
+
+- Поведение `zellij action new-tab` может зависеть от версии CLI и требовать
+  дополнительного способа адресации session/tab.
+- Между созданием session и добавлением analysis tab возможен короткий race,
+  если `zellij` еще не готов принять `action`.
+- Ошибка в выборе fallback-команды для `layout = None` может снова вернуть bare
+  UX вместо штатного default UX.
+- Невалидное имя пользовательского layout должно приводить к явной ошибке, а не
+  к тихому запуску в неправильной конфигурации.
+
+## Architecture Notes
+
+Лучше не смешивать три разные обязанности в одной строке shell-команды:
+
+- определение, существует ли session;
+- создание базовой session;
+- добавление analysis tab.
+
+Практически это означает, что `launch_issue_analysis()` стоит разложить на
+небольшие внутренние шаги или builder'ы команд, чтобы unit-тесты проверяли
+ветки `existing session`, `custom layout`, `default fallback` независимо.
+
+## ADR Impact
+
+Новый ADR не требуется, если решение остается локальным расширением текущего
+контракта `zellij` launcher'а и не меняет SSOT/ADR по execution model.
+
+ADR понадобится только если будет принято проектное решение:
+
+- поддерживать не только имя layout, но и путь к `.kdl`;
+- вводить новый общий тип launcher layout contract для разных режимов запуска.
+
+## Alternatives Considered
+
+### Поддержать сразу и имя layout, и путь к `.kdl`
+
+Не брать в первую версию.
+
+Это расширяет формат конфига и вносит новый слой валидации, хотя issue требует
+только опциональный именованный layout и корректный fallback.
+
+### Оставить создание новой session через generated layout
+
+Отклонено.
+
+Это противоречит dogfooding finding из issue и не решает потерю default UX.
+
+## Migration Or Rollout Notes
+
+- Существующие `settings.yml` должны продолжить десериализоваться без изменений.
+- `templates/init/settings.yml` получает только закомментированный пример, без
+  изменения обязательного шаблона.
+- Rollout безопасен как backward-compatible изменение, если ветка
+  `session exists` остается без функциональной регрессии.

--- a/specs/issues/12/03-how-we-verify.md
+++ b/specs/issues/12/03-how-we-verify.md
@@ -1,0 +1,84 @@
+# Issue 12: Как проверяем
+
+## Acceptance Criteria
+
+1. `zellij.layout` поддерживается как опциональное строковое поле в
+   `./.ai-teamlead/settings.yml`.
+2. Старые конфиги без `zellij.layout` продолжают успешно десериализоваться и
+   валидироваться.
+3. Если session уже существует, launcher по-прежнему добавляет analysis tab
+   через generated layout без изменения текущего поведения.
+4. Если session не существует и `zellij.layout` задан, новая session создается
+   через пользовательский layout, после чего analysis tab добавляется отдельно.
+5. Если session не существует и `zellij.layout` не задан, новая session
+   стартует с нормальным default UX `zellij`, а analysis tab добавляется
+   отдельно.
+6. Ошибки создания session или добавления analysis tab не скрываются и дают
+   диагностируемое сообщение.
+
+## Happy Path
+
+1. Конфиг с `zellij.layout = "my-custom-layout"` загружается без специальных
+   миграций.
+2. Launcher видит, что session отсутствует.
+3. Launcher создает session с пользовательским layout.
+4. Launcher добавляет analysis tab из `launch-layout.kdl`.
+5. `launch-agent.sh` стартует внутри analysis pane как и раньше.
+
+## Edge Cases
+
+- `zellij.layout` отсутствует полностью.
+- `zellij.layout` задан пустой или несуществующей строкой.
+- Session между проверкой `list-sessions` и запуском успевает появиться.
+- Базовая session создается успешно, но добавление analysis tab завершается
+  ошибкой.
+
+## Test Plan
+
+Unit tests:
+
+- парсинг `Config` с `zellij.layout` и без него;
+- отсутствие регрессии валидации для старого YAML;
+- launcher для `session missing` + custom layout собирает ожидаемую команду
+  создания session;
+- launcher для `session missing` + no layout собирает fallback-команду без bare
+  generated layout;
+- launcher для `session exists` сохраняет прежнюю команду добавления tab;
+- если логика будет разложена на несколько шагов, проверить порядок вызовов:
+  сначала base session, потом analysis tab.
+
+Integration / smoke:
+
+- живой прогон на `zellij` с `layout` в тестовом конфиге и проверкой, что
+  analysis tab появился в session;
+- живой прогон без `layout` и проверкой, что session стартует с нормальным
+  default UX, а не через минимальный `launch-layout.kdl`;
+- регрессия существующего integration flow вокруг `internal launch-zellij-fixture`
+  и binding `pane_id/tab_id`.
+
+## Verification Checklist
+
+- шаблон `templates/init/settings.yml` содержит закомментированный пример
+  `layout`;
+- `cargo test` проходит для unit-тестов `config` и `zellij`;
+- при ручном запуске без `layout` пользователь видит обычный UX `zellij`;
+- при ручном запуске с `layout` пользователь видит свой layout и отдельный
+  analysis tab;
+- runtime-артефакты `pane-entrypoint.sh` и `launch-layout.kdl` продолжают
+  создаваться в session directory.
+
+## Failure Scenarios
+
+- Неизвестный layout: launcher завершается ошибкой, не делая вид, что session
+  создана успешно.
+- Session поднялась, но analysis tab не добавился: ошибка должна быть явной,
+  чтобы оператор мог повторить запуск и не потерять диагностику.
+- Сломан fallback без `layout`: smoke-проверка должна выявить возврат к bare UX.
+
+## Observability
+
+- В unit-тестах нужно проверять конкретные команды, переданные в `Shell`.
+- Ошибки `zellij` должны оборачиваться контекстом шага: создание session или
+  добавление analysis tab.
+- Для ручной отладки остаются runtime-артефакты в `.git/.ai-teamlead/sessions`
+  и manifest binding с `session_id`, `tab_id`, `pane_id`.

--- a/specs/issues/12/README.md
+++ b/specs/issues/12/README.md
@@ -1,0 +1,49 @@
+# Issue 12: `zellij` layout при создании сессии
+
+Статус: draft, ready for plan review
+Тип задачи: feature
+Размер: medium
+Последнее обновление: 2026-03-13
+
+## Контекст
+
+Issue: `zellij: опциональный layout при создании сессии`
+
+- GitHub: https://github.com/dapi/ai-teamlead/issues/12
+- Analysis branch: `analysis/issue-12`
+- Session UUID: `e4c49c59-1bb8-4550-8e89-eb00515ea098`
+
+Проблема состоит из двух связанных частей:
+
+1. Сейчас новая `zellij` session создается через сгенерированный минимальный
+   `launch-layout.kdl`, поэтому пользователь не может подключить свой именованный
+   layout из `zellij`.
+2. Когда `zellij.layout` не задан, launcher все равно стартует session в
+   "bare" режиме и теряет привычный default UX `zellij`.
+
+Цель анализа: зафиксировать минимальный дизайн, в котором новая session может
+стартовать либо с пользовательским layout, либо с нормальным built-in default
+UX, а analysis tab продолжает добавляться автоматически.
+
+## Артефакты
+
+## Что строим
+
+- [01-what-we-build.md](/home/danil/worktrees/ai-teamlead/analysis/issue-12/specs/issues/12/01-what-we-build.md)
+
+## Как строим
+
+- [02-how-we-build.md](/home/danil/worktrees/ai-teamlead/analysis/issue-12/specs/issues/12/02-how-we-build.md)
+
+## Как проверяем
+
+- [03-how-we-verify.md](/home/danil/worktrees/ai-teamlead/analysis/issue-12/specs/issues/12/03-how-we-verify.md)
+
+## Вывод анализа
+
+Информации в issue достаточно, чтобы готовить план реализации без дополнительных
+вопросов пользователю.
+
+Новый ADR на текущем этапе не требуется, если в реализации останется контракт:
+`zellij.layout` принимает только строковое имя layout, а fallback без поля
+сохраняет обычный UX `zellij` без расширения формата конфига.


### PR DESCRIPTION
## Summary
- add the versioned SDD analysis artifacts for issue 12
- document what we build, how we build it, and how we verify it
- capture the remaining zellij CLI risk around adding the analysis tab after session creation

Refs #12