### PR TITLE
feat: prefer current zellij session for launches

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ launch_agent:
   analysis_artifacts_dir_template: "specs/issues/${ISSUE_NUMBER}"
 ```
 
-`zellij.session_name` и `zellij.tab_name` задают стабильный project-local
-launcher context.
+`zellij.session_name` задает versioned fallback для target session, а
+`zellij.tab_name` задает versioned target tab.
 
 Bootstrap default для `zellij.session_name` хранится в `settings.yml` как
 template `${REPO}`. Во время реального запуска `ai-teamlead` подставляет сюда
@@ -174,7 +174,11 @@ canonical GitHub repo slug из `origin`.
 
 Во время реального запуска `ai-teamlead`:
 
-- использует эти имена, чтобы найти или создать нужные session/tab
+- выбирает target session в порядке:
+  `--zellij-session` -> `ZELLIJ_SESSION_NAME` -> `zellij.session_name`
+- использует выбранную session и `zellij.tab_name`, чтобы найти или создать
+  нужные session/tab
+- для existing session валидирует, что в ней нет panes из другого GitHub repo
 - сохраняет runtime `session_id`, `tab_id`, `pane_id` уже в `.git/.ai-teamlead/`
 
 Обязательные поля MVP:

--- a/docs/adr/0005-cli-contract-for-poll-and-run.md
+++ b/docs/adr/0005-cli-contract-for-poll-and-run.md
@@ -38,6 +38,8 @@
 
 - `poll` не принимает issue как аргумент
 - `run` принимает идентификатор issue или URL issue
+- `poll` и `run` могут принимать optional override
+  `--zellij-session <SESSION>` для target launcher context
 - обе команды работают в контексте текущего репозитория и его
   `./.ai-teamlead/settings.yml`
 - обе команды используют ту же статусную модель GitHub Project
@@ -59,3 +61,11 @@
 
 - [docs/issue-analysis-flow.md](/home/danil/code/teamlead/docs/issue-analysis-flow.md)
 - [docs/features/0001-ai-teamlead-daemon/README.md](/home/danil/code/teamlead/docs/features/0001-ai-teamlead-daemon/README.md)
+- [docs/adr/0021-zellij-session-target-resolution.md](/home/danil/code/teamlead/docs/adr/0021-zellij-session-target-resolution.md)
+
+## Журнал изменений
+
+### 2026-03-14
+
+- добавлен optional CLI override `--zellij-session <SESSION>` для `poll` и
+  `run`

--- a/docs/adr/0014-zellij-launch-context-naming.md
+++ b/docs/adr/0014-zellij-launch-context-naming.md
@@ -1,6 +1,6 @@
 # ADR-0014: Naming contract для `zellij` launch context
 
-Статус: accepted
+Статус: superseded by ADR-0021
 Дата: 2026-03-13
 
 ## Контекст
@@ -79,3 +79,5 @@ Runtime `zellij` identifiers не хранятся в versioned config:
 - bootstrap placeholder `__SESSION_NAME__` удален из init-шаблона
 - default для `zellij.session_name` переведен на `${REPO}`
 - рендеринг `zellij.session_name` унифицирован с общим template contract
+- дальнейший выбор effective target session вынесен в
+  [ADR-0021](./0021-zellij-session-target-resolution.md)

--- a/docs/adr/0021-zellij-session-target-resolution.md
+++ b/docs/adr/0021-zellij-session-target-resolution.md
@@ -1,0 +1,80 @@
+# ADR-0021: Приоритет разрешения target session для `zellij`
+
+Статус: accepted
+Дата: 2026-03-14
+
+## Контекст
+
+До этого `ai-teamlead` выбирал target session для launcher только по
+`zellij.session_name` из `settings.yml`.
+
+Этого недостаточно для интерактивного сценария, когда оператор уже находится
+внутри нужной `zellij` session и ожидает, что новый tab/pane откроется именно
+там, а не в отдельной session по fallback-имени из конфига.
+
+Дополнительно нужно было зафиксировать:
+
+- одинаковое поведение для `poll` и `run`
+- явный приоритет между CLI override, текущим runtime-контекстом и fallback
+  конфигом
+- запрет на использование одной existing `zellij` session для нескольких
+  GitHub-репозиториев
+
+## Решение
+
+Target session для launcher определяется в таком порядке:
+
+1. явный CLI override `--zellij-session <SESSION>`
+2. `ZELLIJ_SESSION_NAME` из окружения текущего процесса
+3. `zellij.session_name` из `./.ai-teamlead/settings.yml`
+
+Это правило действует одинаково для:
+
+- `poll`
+- `run`
+
+При этом:
+
+- `zellij.session_name` остается versioned project-local fallback-полем
+- bootstrap default для `zellij.session_name` остается `${REPO}`
+- `zellij.tab_name` остается versioned именем tab внутри выбранной session
+
+Для existing session вводится дополнительный runtime guard:
+
+- перед открытием нового tab/pane `ai-teamlead` проверяет panes target session
+- если в existing session обнаружены panes из другого GitHub repo, запуск
+  завершается ошибкой
+- использовать одну shared `zellij` session для нескольких репозиториев
+  запрещено
+
+## Последствия
+
+Плюсы:
+
+- интерактивный запуск по умолчанию попадает в текущую session оператора
+- у оператора остается явный override для нестандартного target session
+- `poll` и `run` используют одинаковый контракт выбора session
+- сохраняется fallback для запуска вне `zellij`
+
+Минусы:
+
+- launcher теперь зависит не только от config, но и от runtime env
+- для existing session появляется дополнительная проверка pane metadata
+- shared multi-repo sessions теперь отбрасываются явно, а не неявно
+
+## Связанные документы
+
+- [ADR-0005](./0005-cli-contract-for-poll-and-run.md)
+- [ADR-0014](./0014-zellij-launch-context-naming.md)
+- [README.md](../../README.md)
+- [Issue Analysis Flow](../issue-analysis-flow.md)
+- [Feature 0003](../features/0003-agent-launch-orchestration/README.md)
+
+## Журнал изменений
+
+### 2026-03-14
+
+- зафиксирован приоритет `args -> env -> settings` для target `zellij`
+  session
+- правило распространено и на `poll`, и на `run`
+- добавлен запрет на shared multi-repo existing sessions

--- a/docs/features/0001-ai-teamlead-daemon/02-how-we-build.md
+++ b/docs/features/0001-ai-teamlead-daemon/02-how-we-build.md
@@ -105,13 +105,14 @@ zellij:
 Здесь:
 
 - `session_name` следует правилу из
-  [ADR-0014](../../../docs/adr/0014-zellij-launch-context-naming.md):
-  default хранится как `${REPO}` и рендерится из GitHub repo slug
-- `session_name` и `tab_name` это стабильные project-local идентификаторы для
-  bootstrap и orchestration
+  [ADR-0021](../../../docs/adr/0021-zellij-session-target-resolution.md):
+  default хранится как `${REPO}` и рендерится из GitHub repo slug, но
+  используется как fallback после CLI override и `ZELLIJ_SESSION_NAME`
+- `tab_name` это стабильный project-local идентификатор для orchestration
 - runtime `session_id`, `tab_id`, `pane_id` не задаются в конфиге
-- `ai-teamlead` во время запуска должен либо найти существующие session/tab по
-  этим именам, либо создать их
+- `ai-teamlead` во время запуска должен выбрать effective target session,
+  запретить shared multi-repo existing session и затем либо найти существующие
+  session/tab, либо создать их
 
 ## Ограничения реализации
 

--- a/docs/features/0003-agent-launch-orchestration/02-how-we-build.md
+++ b/docs/features/0003-agent-launch-orchestration/02-how-we-build.md
@@ -47,7 +47,7 @@ Orchestration flow делится на две части:
 
 ## Zellij context
 
-В `settings.yml` фиксируются только stable names:
+В `settings.yml` фиксируются versioned fallback-поля launcher context:
 
 - `zellij.session_name`
 - `zellij.tab_name`
@@ -59,11 +59,15 @@ Bootstrap default:
 
 Runtime правила:
 
-- если session с таким именем уже существует, используется она
-- если session отсутствует, `ai-teamlead` создает ее
+- target session определяется в порядке:
+  `--zellij-session` -> `ZELLIJ_SESSION_NAME` -> `zellij.session_name`
+- если effective target session уже существует, используется она
+- если effective target session отсутствует, `ai-teamlead` создает ее
 - если нужный tab существует, используется он
 - если нужного tab нет, `ai-teamlead` создает его
 - для каждого запуска issue-analysis открывается новая pane
+- existing session с panes из другого GitHub repo считается недопустимой
+  и отклоняется до запуска
 
 После старта pane:
 
@@ -111,6 +115,7 @@ Bootstrap default для первой версии:
 
 - использовать существующую session
 - не создавать вторую session с тем же semantic назначением
+- перед запуском проверить, что existing session не смешивает несколько repo
 
 ### 2. Session была раньше, но сейчас отсутствует
 
@@ -134,6 +139,14 @@ Bootstrap default для первой версии:
 
 - использовать этот tab как launch context
 - открывать новую pane внутри него
+
+### 7. Existing session содержит panes другого repo
+
+Поведение:
+
+- launcher анализирует `pane_cwd` и repo context existing session
+- если обнаружен другой GitHub repo, запуск завершается ошибкой
+- shared multi-repo session не используется как launch context
 
 ### 5. Tab с нужным именем отсутствует
 
@@ -211,3 +224,5 @@ launch_agent:
 - literal-значения без placeholder допустимы
 - `${REPO}` рендерится из canonical GitHub repo slug
 - любые оставшиеся `${...}` считаются ошибкой конфигурации
+- полученное значение используется как fallback, если нет CLI override и
+  `ZELLIJ_SESSION_NAME`

--- a/docs/features/0003-agent-launch-orchestration/03-how-we-verify.md
+++ b/docs/features/0003-agent-launch-orchestration/03-how-we-verify.md
@@ -11,8 +11,10 @@
 - вторым аргументом в `launch-agent.sh` передается `issue_url`
 - branch/worktree подготавливаются до запуска реального агента
 - branch/worktree/artifacts naming читаются из `settings.yml`
-- `ai-teamlead` корректно находит или создает `zellij` session по
-  `session_name`
+- `ai-teamlead` корректно выбирает target `zellij` session по правилу
+  `args -> env -> settings`
+- `ai-teamlead` корректно находит или создает `zellij` session по effective
+  target session
 - `ai-teamlead` корректно находит или создает tab по `tab_name`
 - после запуска pane в runtime state записывается `pane_id`
 
@@ -30,9 +32,12 @@ Feature считается готовой, если:
 
 - `issue-analysis-flow` не является orchestration-документом
 - `launch-agent.sh` является versioned project-local script
-- `session_name` и `tab_name` являются stable semantic names
+- `zellij.session_name` является versioned fallback, а не единственным
+  источником target session
+- `zellij.tab_name` является stable semantic name
 - `pane_id` является runtime-only значением
 - runtime не генерирует отдельный launcher-script для pane
+- shared multi-repo existing session запрещена
 
 ## Сценарии проверки
 
@@ -50,25 +55,43 @@ Feature считается готовой, если:
 - используется существующая session
 - в нужном tab открывается новая pane
 
-### Сценарий 3. Session пропала
+### Сценарий 3. Команда запущена внутри `zellij`
+
+- `run` или `poll` запускается с `ZELLIJ_SESSION_NAME`
+- CLI override отсутствует
+- используется текущая session из окружения, а не fallback из `settings.yml`
+
+### Сценарий 4. CLI override задан явно
+
+- `run` или `poll` запускается с `--zellij-session`
+- в окружении также может присутствовать `ZELLIJ_SESSION_NAME`
+- используется session из CLI override
+
+### Сценарий 5. Session пропала
 
 - session с ожидаемым именем отсутствует
 - `run` или `poll` запускает recreate session
 - flow продолжается без ручного вмешательства
 
-### Сценарий 4. Session resurrect-нулась
+### Сценарий 6. Session resurrect-нулась
 
 - session существует под ожидаемым именем
 - `run` или `poll` использует ее как existing session
 - новая pane создается успешно
 
-### Сценарий 5. Несколько tab с одинаковым именем
+### Сценарий 7. Existing session содержит другой repo
+
+- launcher обнаруживает panes другого GitHub repo в выбранной session
+- запуск завершается ошибкой
+- issue не должна silently уходить в shared multi-repo session
+
+### Сценарий 8. Несколько tab с одинаковым именем
 
 - launcher обнаруживает неоднозначный tab context
 - запуск завершается ошибкой
 - issue не должна silently уходить в непредсказуемый pane
 
-### Сценарий 6. Launcher-script подготавливает analysis worktree
+### Сценарий 9. Launcher-script подготавливает analysis worktree
 
 - `run` или `poll` открывает новую pane
 - pane запускает `./.ai-teamlead/launch-agent.sh`
@@ -77,12 +100,12 @@ Feature считается готовой, если:
 - создает каталог versioned analysis-артефактов
 - только после этого может стартовать реальный агент
 
-### Сценарий 7. Измененные templates в `settings.yml`
+### Сценарий 10. Измененные templates в `settings.yml`
 
 - владелец репозитория меняет branch/worktree/artifacts templates
 - `launch-agent.sh` использует новые значения без изменения core-кода
 
-### Сценарий 8. `codex` недоступен
+### Сценарий 11. `codex` недоступен
 
 - launcher подготовил analysis worktree
 - `codex` отсутствует в окружении
@@ -93,7 +116,7 @@ Feature считается готовой, если:
 
 Минимально необходимо видеть:
 
-- какой `session_name` ожидался
+- какой effective `session_name` ожидался
 - какой `tab_name` ожидался
 - существовала ли session до запуска
 - был ли создан новый tab

--- a/docs/issue-analysis-flow.md
+++ b/docs/issue-analysis-flow.md
@@ -176,9 +176,12 @@ Poller или ручной запуск выбирает одну подходя
 
 - генерируется `session_uuid`
 - issue связывается с этим `session_uuid` в отношении `1 <-> 1`
-- конфигурация проекта задает стабильные `zellij.session_name` и
-  `zellij.tab_name`
-- orchestration-слой создает или находит нужные session/tab по этим именам
+- target `zellij` session определяется в порядке:
+  `--zellij-session` -> `ZELLIJ_SESSION_NAME` -> `zellij.session_name`
+- `zellij.tab_name` задается конфигурацией проекта
+- orchestration-слой создает или находит нужные session/tab по effective target
+  session и `tab_name`
+- existing session не должна содержать panes из другого GitHub repo
 - после запуска pane в runtime state сохраняются `zellij.session_id`,
   `zellij.tab_id` и `zellij.pane_id`
 - session-артефакты сохраняются в `.git/.ai-teamlead/`

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,8 +23,12 @@ pub fn run() -> Result<()> {
 
     match cli.command {
         Command::Init => run_init(&shell),
-        Command::Poll => run_poll(&shell),
-        Command::Run { issue, debug } => run_manual_run(&shell, &issue, debug),
+        Command::Poll { zellij_session } => run_poll(&shell, zellij_session.as_deref()),
+        Command::Run {
+            issue,
+            debug,
+            zellij_session,
+        } => run_manual_run(&shell, &issue, debug, zellij_session.as_deref()),
         Command::Internal { internal } => run_internal(&shell, internal),
     }
 }
@@ -51,8 +55,8 @@ fn run_init(shell: &dyn Shell) -> Result<()> {
     Ok(())
 }
 
-fn run_poll(shell: &dyn Shell) -> Result<()> {
-    let context = load_execution_context(shell)?;
+fn run_poll(shell: &dyn Shell, zellij_session_override: Option<&str>) -> Result<()> {
+    let context = load_execution_context(shell, zellij_session_override)?;
     let github = GhProjectClient::new(shell);
     let zellij = ZellijLauncher::new(shell);
     let snapshot =
@@ -96,6 +100,7 @@ fn run_poll(shell: &dyn Shell) -> Result<()> {
     );
     let binary_path = std::env::current_exe().context("failed to resolve ai-teamlead binary")?;
     if let Err(error) = zellij.launch_issue_analysis(
+        &context.repo,
         &context.repo.repo_root,
         &context.runtime,
         &context.config.zellij,
@@ -140,8 +145,13 @@ fn run_poll(shell: &dyn Shell) -> Result<()> {
     Ok(())
 }
 
-fn run_manual_run(shell: &dyn Shell, issue_ref: &str, debug: bool) -> Result<()> {
-    let context = load_execution_context(shell)?;
+fn run_manual_run(
+    shell: &dyn Shell,
+    issue_ref: &str,
+    debug: bool,
+    zellij_session_override: Option<&str>,
+) -> Result<()> {
+    let context = load_execution_context(shell, zellij_session_override)?;
     let github = GhProjectClient::new(shell);
     let zellij = ZellijLauncher::new(shell);
     let snapshot =
@@ -230,6 +240,7 @@ fn run_manual_run(shell: &dyn Shell, issue_ref: &str, debug: bool) -> Result<()>
     );
     let binary_path = std::env::current_exe().context("failed to resolve ai-teamlead binary")?;
     zellij.launch_issue_analysis(
+        &context.repo,
         &context.repo.repo_root,
         &context.runtime,
         &context.config.zellij,
@@ -317,7 +328,7 @@ fn run_internal(shell: &dyn Shell, internal: InternalCommand) -> Result<()> {
 }
 
 fn run_internal_bind_zellij_pane(shell: &dyn Shell, session_uuid: &str) -> Result<()> {
-    let context = load_execution_context(shell)?;
+    let context = load_execution_context(shell, None)?;
     let (session_id, tab_id, pane_id) = capture_current_binding(
         shell,
         &context.repo.repo_root,
@@ -333,7 +344,7 @@ fn run_internal_bind_zellij_pane(shell: &dyn Shell, session_uuid: &str) -> Resul
 }
 
 fn run_internal_launch_zellij_fixture(shell: &dyn Shell, issue_number: u64) -> Result<()> {
-    let context = load_execution_context(shell)?;
+    let context = load_execution_context(shell, None)?;
     let manifest = context.runtime.create_claim_binding(
         &context.repo,
         &context.config.github.project_id,
@@ -347,6 +358,7 @@ fn run_internal_launch_zellij_fixture(shell: &dyn Shell, issue_number: u64) -> R
     );
     let binary_path = std::env::current_exe().context("failed to resolve ai-teamlead binary")?;
     zellij.launch_issue_analysis(
+        &context.repo,
         &context.repo.repo_root,
         &context.runtime,
         &context.config.zellij,
@@ -363,7 +375,7 @@ fn run_internal_launch_zellij_fixture(shell: &dyn Shell, issue_number: u64) -> R
 }
 
 fn run_internal_render_launch_agent_context(shell: &dyn Shell, issue_ref: &str) -> Result<()> {
-    let context = load_execution_context(shell)?;
+    let context = load_execution_context(shell, None)?;
     let issue_number = parse_issue_ref(issue_ref)
         .with_context(|| format!("failed to parse issue reference: {issue_ref}"))?;
     let rendered = render_launch_agent_context(&context, issue_number)?;
@@ -388,16 +400,28 @@ struct ExecutionContext {
     runtime: RuntimeLayout,
 }
 
-fn load_execution_context(shell: &dyn Shell) -> Result<ExecutionContext> {
+fn load_execution_context(
+    shell: &dyn Shell,
+    zellij_session_override: Option<&str>,
+) -> Result<ExecutionContext> {
     let cwd = std::env::current_dir().context("failed to get current directory")?;
-    load_execution_context_at(shell, cwd)
+    load_execution_context_at(shell, cwd, zellij_session_override)
 }
 
-fn load_execution_context_at(shell: &dyn Shell, cwd: PathBuf) -> Result<ExecutionContext> {
+fn load_execution_context_at(
+    shell: &dyn Shell,
+    cwd: PathBuf,
+    zellij_session_override: Option<&str>,
+) -> Result<ExecutionContext> {
     let repo = RepoContext::discover(shell, &cwd)?;
     let mut config = Config::load_from_repo_root(&repo.repo_root)?;
-    config.zellij.session_name =
+    let configured_session_name =
         render_zellij_session_name(&config.zellij.session_name, &repo.github_repo)?;
+    config.zellij.session_name = resolve_zellij_session_name(
+        &configured_session_name,
+        zellij_session_override,
+        std::env::var("ZELLIJ_SESSION_NAME").ok().as_deref(),
+    );
     let runtime = RuntimeLayout::from_repo_root(&repo.repo_root);
     runtime.ensure_exists()?;
 
@@ -406,6 +430,23 @@ fn load_execution_context_at(shell: &dyn Shell, cwd: PathBuf) -> Result<Executio
         config,
         runtime,
     })
+}
+
+fn resolve_zellij_session_name(
+    configured_session_name: &str,
+    zellij_session_override: Option<&str>,
+    zellij_session_from_env: Option<&str>,
+) -> String {
+    zellij_session_override
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            zellij_session_from_env
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        })
+        .unwrap_or(configured_session_name)
+        .to_string()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -459,6 +500,39 @@ fn render_launch_agent_context(
         worktree_root,
         analysis_artifacts_dir,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_zellij_session_name;
+
+    #[test]
+    fn zellij_session_override_has_highest_priority() {
+        let resolved = resolve_zellij_session_name(
+            "settings-session",
+            Some("cli-session"),
+            Some("env-session"),
+        );
+        assert_eq!(resolved, "cli-session");
+    }
+
+    #[test]
+    fn zellij_session_from_env_beats_settings() {
+        let resolved = resolve_zellij_session_name("settings-session", None, Some("env-session"));
+        assert_eq!(resolved, "env-session");
+    }
+
+    #[test]
+    fn zellij_session_falls_back_to_settings() {
+        let resolved = resolve_zellij_session_name("settings-session", None, None);
+        assert_eq!(resolved, "settings-session");
+    }
+
+    #[test]
+    fn zellij_session_ignores_blank_override_and_env() {
+        let resolved = resolve_zellij_session_name("settings-session", Some("   "), Some(""));
+        assert_eq!(resolved, "settings-session");
+    }
 }
 
 fn shell_quote(value: &str) -> String {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,10 +11,15 @@ pub struct Cli {
 #[derive(Debug, Subcommand)]
 pub enum Command {
     Init,
-    Poll,
+    Poll {
+        #[arg(long = "zellij-session", value_name = "SESSION")]
+        zellij_session: Option<String>,
+    },
     Run {
         #[arg(short = 'd', long = "debug")]
         debug: bool,
+        #[arg(long = "zellij-session", value_name = "SESSION")]
+        zellij_session: Option<String>,
         issue: String,
     },
     #[command(hide = true)]

--- a/src/zellij.rs
+++ b/src/zellij.rs
@@ -1,10 +1,12 @@
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use serde_json::Value;
 
 use crate::config::ZellijConfig;
+use crate::repo::RepoContext;
 use crate::runtime::RuntimeLayout;
 use crate::shell::Shell;
 
@@ -19,6 +21,7 @@ impl<'a> ZellijLauncher<'a> {
 
     pub fn launch_issue_analysis(
         &self,
+        repo: &RepoContext,
         repo_root: &Path,
         runtime: &RuntimeLayout,
         zellij: &ZellijConfig,
@@ -95,6 +98,7 @@ exec {quoted_launch_agent} {quoted_session_uuid} {quoted_issue_url}\n"
         let layout_str = layout_path.to_string_lossy();
 
         if session_exists {
+            ensure_session_repo_scope(self.shell, repo_root, repo, &zellij.session_name)?;
             // For existing sessions: use `zellij action new-tab` IPC command.
             // This does not create an attached client and does not need a PTY,
             // so there is no risk of cascading server shutdown.
@@ -127,6 +131,59 @@ exec {quoted_launch_agent} {quoted_session_uuid} {quoted_issue_url}\n"
             )
         }
     }
+}
+
+fn ensure_session_repo_scope(
+    shell: &dyn Shell,
+    repo_root: &Path,
+    repo: &RepoContext,
+    session_name: &str,
+) -> Result<()> {
+    let panes_output = shell.run_with_env(
+        repo_root,
+        &[("ZELLIJ", "0"), ("ZELLIJ_SESSION_NAME", session_name)],
+        "zellij",
+        &["action", "list-panes", "--json", "-a", "-c", "-t", "-s"],
+    )?;
+    let foreign_repos = find_foreign_repos_in_session(shell, &panes_output, repo)?;
+    if foreign_repos.is_empty() {
+        return Ok(());
+    }
+
+    bail!(
+        "zellij session '{}' already contains panes from other repos: {}; shared multi-repo sessions are not allowed",
+        session_name,
+        foreign_repos.into_iter().collect::<Vec<_>>().join(", ")
+    );
+}
+
+fn find_foreign_repos_in_session(
+    shell: &dyn Shell,
+    panes_output: &str,
+    repo: &RepoContext,
+) -> Result<BTreeSet<String>> {
+    let value: Value = serde_json::from_str(panes_output)
+        .context("failed to parse zellij pane metadata while validating session repo scope")?;
+    let mut pane_cwds = BTreeSet::new();
+    collect_pane_cwds(&value, &mut pane_cwds);
+
+    let expected_repo = format!("{}/{}", repo.github_owner, repo.github_repo);
+    let mut foreign_repos = BTreeSet::new();
+    for pane_cwd in pane_cwds {
+        let pane_path = Path::new(&pane_cwd);
+        if !pane_path.is_dir() {
+            continue;
+        }
+        let Ok(pane_repo) = RepoContext::discover(shell, pane_path) else {
+            continue;
+        };
+        let pane_repo_slug = format!("{}/{}", pane_repo.github_owner, pane_repo.github_repo);
+        if pane_repo_slug != expected_repo {
+            foreign_repos.insert(pane_repo_slug);
+        }
+    }
+
+    Ok(foreign_repos)
 }
 
 pub fn capture_current_binding(
@@ -211,6 +268,25 @@ fn find_object_for_pane<'a>(value: &'a Value, pane_id: &str) -> Option<&'a Value
     }
 }
 
+fn collect_pane_cwds(value: &Value, pane_cwds: &mut BTreeSet<String>) {
+    match value {
+        Value::Object(map) => {
+            if let Some(cwd) = map.get("pane_cwd").and_then(value_to_string) {
+                pane_cwds.insert(cwd);
+            }
+            for child in map.values() {
+                collect_pane_cwds(child, pane_cwds);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                collect_pane_cwds(child, pane_cwds);
+            }
+        }
+        _ => {}
+    }
+}
+
 fn find_first_scalar_by_keys(value: &Value, keys: &[&str]) -> Option<String> {
     match value {
         Value::Object(map) => {
@@ -256,6 +332,7 @@ mod tests {
 
     use super::{ZellijLauncher, resolve_tab_id, resolve_tab_id_from_panes};
     use crate::config::ZellijConfig;
+    use crate::repo::RepoContext;
     use crate::runtime::RuntimeLayout;
     use crate::shell::Shell;
 
@@ -271,10 +348,28 @@ mod tests {
             self.responses.insert(key.to_string(), value.to_string());
             self
         }
+
+        fn with_cwd_response(
+            mut self,
+            cwd: &Path,
+            program: &str,
+            args: &[&str],
+            value: &str,
+        ) -> Self {
+            self.responses.insert(
+                format!("cwd={}::{program} {}", cwd.display(), args.join(" ")),
+                value.to_string(),
+            );
+            self
+        }
     }
 
     impl Shell for FakeShell {
         fn run(&self, _cwd: &Path, program: &str, args: &[&str]) -> Result<String> {
+            let cwd_key = format!("cwd={}::{program} {}", _cwd.display(), args.join(" "));
+            if let Some(value) = self.responses.get(&cwd_key) {
+                return Ok(value.clone());
+            }
             let key = format!("{program} {}", args.join(" "));
             self.responses
                 .get(&key)
@@ -289,6 +384,10 @@ mod tests {
             program: &str,
             args: &[&str],
         ) -> Result<String> {
+            let cwd_key = format!("cwd={}::{program} {}", _cwd.display(), args.join(" "));
+            if let Some(value) = self.responses.get(&cwd_key) {
+                return Ok(value.clone());
+            }
             let key = format!("{program} {}", args.join(" "));
             let env_pairs: Vec<(String, String)> = envs
                 .iter()
@@ -354,6 +453,12 @@ mod tests {
 
         let shell = FakeShell::default().with_response("zellij list-sessions --short", "");
         let launcher = ZellijLauncher::new(&shell);
+        let repo = RepoContext {
+            repo_root: repo_root.clone(),
+            git_dir: git_dir.clone(),
+            github_owner: "dapi".into(),
+            github_repo: "teamlead".into(),
+        };
         let zellij = ZellijConfig {
             session_name: "ai-teamlead".into(),
             tab_name: "issue-analysis".into(),
@@ -361,6 +466,7 @@ mod tests {
 
         launcher
             .launch_issue_analysis(
+                &repo,
                 &repo_root,
                 &runtime,
                 &zellij,
@@ -413,8 +519,34 @@ mod tests {
 
         let shell = FakeShell::default()
             .with_response("zellij list-sessions --short", "ai-teamlead")
+            .with_response(
+                "zellij action list-panes --json -a -c -t -s",
+                &format!(
+                    r#"[{{"id":"terminal_1","pane_cwd":"{}"}}]"#,
+                    repo_root.display()
+                ),
+            )
+            .with_cwd_response(
+                &repo_root,
+                "git",
+                &["rev-parse", "--show-toplevel"],
+                repo_root.to_string_lossy().as_ref(),
+            )
+            .with_cwd_response(&repo_root, "git", &["rev-parse", "--git-dir"], ".git")
+            .with_cwd_response(
+                &repo_root,
+                "git",
+                &["remote", "get-url", "origin"],
+                "git@github.com:dapi/teamlead.git",
+            )
             .with_response("zellij action new-tab --layout", "");
         let launcher = ZellijLauncher::new(&shell);
+        let repo = RepoContext {
+            repo_root: repo_root.clone(),
+            git_dir: git_dir.clone(),
+            github_owner: "dapi".into(),
+            github_repo: "teamlead".into(),
+        };
         let zellij = ZellijConfig {
             session_name: "ai-teamlead".into(),
             tab_name: "issue-analysis".into(),
@@ -422,6 +554,7 @@ mod tests {
 
         launcher
             .launch_issue_analysis(
+                &repo,
                 &repo_root,
                 &runtime,
                 &zellij,
@@ -459,6 +592,77 @@ mod tests {
     }
 
     #[test]
+    fn launcher_rejects_existing_session_with_foreign_repo_panes() {
+        let temp = tempdir().expect("temp dir");
+        let repo_root = temp.path().join("repo");
+        let foreign_root = temp.path().join("foreign");
+        let git_dir = repo_root.join(".git");
+        std::fs::create_dir_all(&git_dir).expect("git dir");
+        std::fs::create_dir_all(&foreign_root).expect("foreign dir");
+
+        let runtime = RuntimeLayout::from_repo_root(&repo_root);
+        runtime.ensure_exists().expect("runtime");
+
+        let shell = FakeShell::default()
+            .with_response("zellij list-sessions --short", "ai-teamlead")
+            .with_response(
+                "zellij action list-panes --json -a -c -t -s",
+                &format!(
+                    r#"[{{"id":"terminal_9","pane_cwd":"{}"}}]"#,
+                    foreign_root.display()
+                ),
+            )
+            .with_cwd_response(
+                &foreign_root,
+                "git",
+                &["rev-parse", "--show-toplevel"],
+                foreign_root.to_string_lossy().as_ref(),
+            )
+            .with_cwd_response(&foreign_root, "git", &["rev-parse", "--git-dir"], ".git")
+            .with_cwd_response(
+                &foreign_root,
+                "git",
+                &["remote", "get-url", "origin"],
+                "git@github.com:dapi/foreign.git",
+            );
+        let launcher = ZellijLauncher::new(&shell);
+        let repo = RepoContext {
+            repo_root: repo_root.clone(),
+            git_dir,
+            github_owner: "dapi".into(),
+            github_repo: "teamlead".into(),
+        };
+        let zellij = ZellijConfig {
+            session_name: "ai-teamlead".into(),
+            tab_name: "issue-analysis".into(),
+        };
+
+        let error = launcher
+            .launch_issue_analysis(
+                &repo,
+                &repo_root,
+                &runtime,
+                &zellij,
+                "https://github.com/dapi/teamlead/issues/42",
+                "session-uuid",
+                Path::new("/tmp/ai-teamlead"),
+                false,
+            )
+            .expect_err("launch should fail for multi-repo session");
+
+        assert!(
+            error
+                .to_string()
+                .contains("shared multi-repo sessions are not allowed"),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            error.to_string().contains("dapi/foreign"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[test]
     fn layout_includes_close_on_exit_false() {
         let temp = tempdir().expect("temp dir");
         let repo_root = temp.path().join("repo");
@@ -470,6 +674,12 @@ mod tests {
 
         let shell = FakeShell::default().with_response("zellij list-sessions --short", "");
         let launcher = ZellijLauncher::new(&shell);
+        let repo = RepoContext {
+            repo_root: repo_root.clone(),
+            git_dir: git_dir.clone(),
+            github_owner: "dapi".into(),
+            github_repo: "teamlead".into(),
+        };
         let zellij = ZellijConfig {
             session_name: "ai-teamlead".into(),
             tab_name: "issue-analysis".into(),
@@ -477,6 +687,7 @@ mod tests {
 
         launcher
             .launch_issue_analysis(
+                &repo,
                 &repo_root,
                 &runtime,
                 &zellij,

--- a/tests/integration/test_03_run_with_stub_agent.sh
+++ b/tests/integration/test_03_run_with_stub_agent.sh
@@ -43,6 +43,7 @@ fi
 WORKTREE_ROOT="${HOME}/worktrees/example/analysis/issue-42"
 ARTIFACTS_DIR="$WORKTREE_ROOT/specs/issues/42"
 PANE_ID="$(wait_for_json_field_not_value "$SESSION_MANIFEST" '.zellij.pane_id' 'pending' 30 || true)"
+SESSION_NAME="$(jq -r '.zellij.session_name' "$SESSION_MANIFEST")"
 wait_for_dir "$WORKTREE_ROOT" 30 || true
 wait_for_dir "$ARTIFACTS_DIR" 30 || true
 wait_for_file "$STUB_OUT/codex.invoked" 30 || true
@@ -60,6 +61,7 @@ assert_eq "$(cat "$STUB_OUT/analysis_branch")" "analysis/issue-42" "run passed a
 assert_eq "$(cat "$STUB_OUT/worktree_root")" "$WORKTREE_ROOT" "run passed worktree root to stub agent"
 assert_eq "$(cat "$STUB_OUT/analysis_artifacts_dir")" "specs/issues/42" "run passed artifacts dir to stub agent"
 assert_eq "$(cat "$STUB_OUT/codex.cwd")" "$WORKTREE_ROOT" "stub agent started in analysis worktree"
+assert_eq "$SESSION_NAME" "example" "run uses rendered settings zellij session outside zellij env"
 assert_ne "$PANE_ID" "" "run captured zellij pane id"
 assert_file_contains "$LAUNCH_LOG" "pane-entrypoint: session_uuid=$SESSION_UUID" "run wrote pane entrypoint bootstrap log"
 assert_file_contains "$LAUNCH_LOG" "launch-agent: starting agent in $WORKTREE_ROOT" "run wrote launch-agent progress log"

--- a/tests/integration/test_05_session_exit_no_server_crash.sh
+++ b/tests/integration/test_05_session_exit_no_server_crash.sh
@@ -6,9 +6,9 @@ set -euo pipefail
 #
 # Scenario:
 #   1. Create an "outer" zellij session (simulates user's terminal)
-#   2. From inside that session, launch ai-teamlead which creates an
-#      "inner" ai-teamlead-test session with a short-lived stub agent
-#   3. Wait for the stub agent to finish and the inner pane to exit
+#   2. From inside that session, launch ai-teamlead which must reuse the
+#      current zellij session by default
+#   3. Wait for the stub agent to finish and the launched pane to exit
 #   4. Verify the outer session is still alive (server not crashed)
 
 AI_TEAMLEAD_BIN="/test/bin/ai-teamlead"
@@ -88,16 +88,20 @@ sleep 6
 # --- Step 4: Verify the outer session survived ---
 assert_session_alive "$OUTER_SESSION" "outer zellij session survives after agent exit (issue #27)"
 
-# Additional check: verify no ZELLIJ env vars leaked into the inner session.
-# The pane-entrypoint or launch log should not reference the outer session.
+# Additional check: verify the runtime binding points at the reused outer
+# session rather than the fallback session from settings.
 ISSUE_INDEX="$REPO_ROOT/.git/.ai-teamlead/issues/99.json"
 if [[ -f "$ISSUE_INDEX" ]]; then
     SESSION_UUID="$(jq -r '.session_uuid' "$ISSUE_INDEX")"
     LAUNCH_LOG="$REPO_ROOT/.git/.ai-teamlead/sessions/$SESSION_UUID/launch.log"
     LAYOUT_FILE="$REPO_ROOT/.git/.ai-teamlead/sessions/$SESSION_UUID/launch-layout.kdl"
+    SESSION_MANIFEST="$REPO_ROOT/.git/.ai-teamlead/sessions/$SESSION_UUID/session.json"
 
     if [[ -f "$LAYOUT_FILE" ]]; then
         assert_file_contains "$LAYOUT_FILE" "close_on_exit false" "layout includes close_on_exit false for pane lifecycle"
+    fi
+    if [[ -f "$SESSION_MANIFEST" ]]; then
+        assert_eq "$(jq -r '.zellij.session_name' "$SESSION_MANIFEST")" "$OUTER_SESSION" "run reused current zellij session from env"
     fi
 fi
 

--- a/tests/integration/test_06_zellij_session_priority.sh
+++ b/tests/integration/test_06_zellij_session_priority.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AI_TEAMLEAD_BIN="/test/bin/ai-teamlead"
+REPO_ROOT="$(mktemp -d /tmp/ai-teamlead-run-priority-XXXXXX)"
+STUB_BIN="$(mktemp -d /tmp/ai-teamlead-run-priority-stub-bin-XXXXXX)"
+STUB_OUT="$(mktemp -d /tmp/ai-teamlead-run-priority-stub-out-XXXXXX)"
+GH_LOG="$(mktemp /tmp/ai-teamlead-run-priority-gh-log-XXXXXX)"
+GH_SNAPSHOT="$(mktemp /tmp/ai-teamlead-run-priority-gh-snapshot-XXXXXX)"
+ENV_SESSION="outer-session-$$"
+ARG_SESSION="cli-session-$$"
+
+create_initialized_repo "$REPO_ROOT" "$AI_TEAMLEAD_BIN"
+
+cat > "$GH_SNAPSHOT" <<'EOF'
+{"data":{"node":{"id":"PVT_test_project","title":"Test Project","field":{"id":"STATUS_FIELD","options":[{"id":"OPT_BACKLOG","name":"Backlog"},{"id":"OPT_ANALYSIS","name":"Analysis In Progress"},{"id":"OPT_CLARIFY","name":"Waiting for Clarification"},{"id":"OPT_PLAN","name":"Waiting for Plan Review"},{"id":"OPT_READY","name":"Ready for Implementation"},{"id":"OPT_BLOCKED","name":"Analysis Blocked"}]},"items":{"nodes":[{"id":"ITEM-42","fieldValueByName":{"name":"Backlog","optionId":"OPT_BACKLOG"},"content":{"number":42,"state":"OPEN","repository":{"name":"example","owner":{"login":"dapi"}}}}]}}}}
+EOF
+
+install_gh_stub "$STUB_BIN" "$GH_SNAPSHOT" "$GH_LOG"
+install_agent_stubs "$STUB_BIN" "$STUB_OUT"
+export PATH="$STUB_BIN:$PATH"
+export AI_TEAMLEAD_STUB_AGENT_SLEEP=8
+export ZELLIJ=0
+export ZELLIJ_SESSION_NAME="$ENV_SESSION"
+
+RUN_OUTPUT="$(
+    cd "$REPO_ROOT"
+    "$AI_TEAMLEAD_BIN" run --zellij-session "$ARG_SESSION" 42 2>&1
+)"
+
+ISSUE_INDEX="$REPO_ROOT/.git/.ai-teamlead/issues/42.json"
+if ! wait_for_file "$ISSUE_INDEX"; then
+    echo "  FAIL: run created issue index"
+    ((FAIL++)) || true
+    return 0
+fi
+
+SESSION_UUID="$(jq -r '.session_uuid' "$ISSUE_INDEX")"
+SESSION_MANIFEST="$REPO_ROOT/.git/.ai-teamlead/sessions/$SESSION_UUID/session.json"
+if ! wait_for_file "$SESSION_MANIFEST"; then
+    echo "  FAIL: run created session manifest"
+    ((FAIL++)) || true
+    return 0
+fi
+
+SESSION_NAME="$(jq -r '.zellij.session_name' "$SESSION_MANIFEST")"
+PANE_ID="$(wait_for_json_field_not_value "$SESSION_MANIFEST" '.zellij.pane_id' 'pending' 30 || true)"
+
+assert_eq "$SESSION_NAME" "$ARG_SESSION" "cli zellij session override beats env session"
+assert_ne "$PANE_ID" "" "cli override launch captured pane id"
+assert_session_alive "$ARG_SESSION" "cli override created requested zellij session"
+assert_text_contains "$RUN_OUTPUT" "zellij_session=$ARG_SESSION" "run printed cli-selected zellij session"


### PR DESCRIPTION
## Что изменено
- добавлен новый runtime-контракт выбора target `zellij` session с приоритетом `--zellij-session -> ZELLIJ_SESSION_NAME -> settings`
- правило применяется одинаково для `poll` и `run`
- добавлен guard против shared `zellij` session с panes из другого GitHub repo
- обновлены ADR, README, SSOT и feature-документы под новый контракт
- добавлены unit и integration tests на fallback по `settings`, reuse текущей session и приоритет CLI override

## Проверка
- `cargo test`
- docker-based integration suite `tests/integration/docker-test-runner.sh`
