### PR TITLE
docs: add feature 0005 agent flow test platform

### DIFF
--- a/docs/features/0005-agent-flow-integration-testing/01-what-we-build.md
+++ b/docs/features/0005-agent-flow-integration-testing/01-what-we-build.md
@@ -1,0 +1,89 @@
+# Feature 0005: Что строим
+
+## Проблема
+
+Сейчас у проекта есть требования к integration tests, но нет канонической
+платформы, которая:
+
+- запускается одной локальной командой
+- создает полностью независимый sandbox для `ai-teamlead`
+- прогоняет реальный launcher path, включая `zellij`
+- умеет запускать настоящего агента (`codex` или `claude`) с локальными
+  настройками и параметрами подключения к LLM API
+- не затрагивает host `zellij` session пользователя
+
+Без такой платформы проверка agent flow остается смесью ручных действий,
+ад-хок shell-скриптов и частичных integration tests с test doubles.
+
+## Пользователь
+
+Основной пользователь:
+
+- владелец репозитория, который меняет flow, launcher, prompt или runtime
+  orchestration и хочет быстро проверить реальный сценарий локально
+
+Вторичные пользователи:
+
+- разработчик `ai-teamlead`, который хочет воспроизводимые integration tests в
+  CI
+- владелец подключенного репозитория, который хочет убедиться, что его
+  project-local `.ai-teamlead/`, `.claude/` и `.codex/` работают в изоляции
+
+## Результат
+
+Полезным результатом считается платформа, в которой пользователь запускает один
+entrypoint и получает:
+
+- отдельный disposable sandbox
+- воспроизводимый прогон одного или нескольких versioned сценариев
+- реальный запуск `ai-teamlead`, `launch-agent.sh` и agent flow
+- выбор режима `stub` или `live`
+- экспорт артефактов прогона: логи, sandbox metadata, runtime-state, итоговый
+  статус и диагностические файлы
+
+## Scope
+
+В первую версию входят:
+
+- единый CLI entrypoint для запуска integration scenarios локально
+- Docker-based headless sandbox как основной и канонический runtime
+- изолированный запуск `zellij` только внутри sandbox
+- snapshot текущего репозитория в disposable workspace
+- запуск реального `ai-teamlead` CLI внутри sandbox
+- запуск `launch-agent.sh` и project-local flow prompt без bypass path
+- два режима агента:
+  - `stub` для детерминированных сценариев и CI
+  - `live` для запуска реального `codex` или `claude`
+- repo-local описание сценариев и expected assertions
+- явный bridge для host env vars и host config files, нужных агенту для доступа
+  к LLM API
+- export test artifacts наружу из sandbox
+
+## Вне scope
+
+В первую версию не входят:
+
+- универсальный browser E2E для произвольных UI
+- автоматический прогон live LLM tests на каждый коммит в CI
+- скрытый доступ sandbox ко всему `$HOME` пользователя
+- поддержка произвольных container runtime без отдельного контракта
+- сравнение качества reasoning модели по содержанию generated plan
+- полная эмуляция GitHub SaaS без выделенного fake/stub слоя
+
+## Ограничения и предпосылки
+
+- host `zellij` пользователя считается off-limits; любые `zellij`-related
+  проверки выполняются только в headless sandbox
+- project-local repo assets остаются источником истины для flow и launcher
+- sandbox не должен менять рабочее дерево пользователя
+- live-режим использует локальные настройки и credentials пользователя, но
+  только через явный allowlist env vars и mounts
+- `stub` и `live` должны использовать один и тот же orchestration path; нельзя
+  делать отдельный shortcut только для тестов
+- результат теста должен быть inspectable без повторного входа в sandbox
+
+## Связанные документы
+
+- [README.md](./README.md)
+- [02-how-we-build.md](./02-how-we-build.md)
+- [03-how-we-verify.md](./03-how-we-verify.md)

--- a/docs/features/0005-agent-flow-integration-testing/02-how-we-build.md
+++ b/docs/features/0005-agent-flow-integration-testing/02-how-we-build.md
@@ -1,0 +1,243 @@
+# Feature 0005: Как строим
+
+## Архитектура
+
+Платформа состоит из пяти слоев:
+
+1. `host entrypoint`
+   Единая CLI-команда, например `ai-teamlead test agent-flow`, которая
+   загружает repo-local config, выбирает сценарий и orchestrate-ит запуск.
+2. `sandbox builder`
+   Подготавливает disposable Docker sandbox с pinned `zellij`, нужными CLI и
+   временным workspace snapshot.
+3. `agent bridge`
+   Передает в sandbox только разрешенные host env vars, credentials и
+   config-files для выбранного agent profile.
+4. `scenario runner`
+   Запускает внутри sandbox `ai-teamlead`, `launch-agent.sh`, fake/stub
+   adapters и assertion hooks.
+5. `artifact collector`
+   Выгружает наружу логи, runtime-state, stdout/stderr, metadata сценария и
+   итоговый verdict.
+
+Канонический path должен выглядеть так:
+
+1. host CLI читает `./.ai-teamlead/settings.yml`
+2. host CLI читает versioned scenario manifest
+3. host CLI собирает sandbox и workspace snapshot
+4. sandbox запускает `ai-teamlead` entrypoint
+5. `ai-teamlead` проходит обычный launcher/orchestration path
+6. выбранный agent profile (`stub`, `codex`, `claude`) отрабатывает внутри того
+   же sandbox
+7. runner выполняет assertions
+8. artifact collector сохраняет результат вне sandbox
+
+## Данные и состояния
+
+### Сущности
+
+- `test run`
+  Отдельный запуск entrypoint с уникальным `run_id`.
+- `scenario`
+  Versioned описание одного integration path со входными данными,
+  environment bridge и assertions.
+- `sandbox`
+  Disposable container runtime и его filesystem.
+- `workspace snapshot`
+  Изолированная копия текущего репозитория для прогона.
+- `agent profile`
+  Набор правил, как запускать `stub`, `codex` или `claude`.
+- `artifact bundle`
+  Экспортируемый результат теста.
+
+### Жизненный цикл `test run`
+
+- `created`
+- `snapshot_prepared`
+- `sandbox_ready`
+- `runtime_started`
+- `agent_running`
+- `asserting`
+- `passed | failed | errored`
+- `artifacts_exported`
+
+Переходы должны быть линейными и диагностируемыми. Повторный запуск создает
+новый `run_id` и не переиспользует mutable state прошлого прогона.
+
+### Workspace snapshot
+
+В MVP snapshot должен включать:
+
+- текущее содержимое репозитория
+- versioned `.ai-teamlead/`, `.claude/`, `.codex/`, если они есть в repo
+- достаточный git context для работы `ai-teamlead`, `git worktree` и launcher
+
+Платформа должна поддержать локальную разработку, поэтому snapshot нельзя
+жестко ограничивать только последним коммитом. Предпочтительный контракт:
+
+- sandbox получает копию текущего working tree
+- исходный host repo остается неизменным
+- все побочные эффекты git/runtime пишутся только внутрь snapshot
+
+## Интерфейсы
+
+### CLI entrypoint
+
+Черновой контракт:
+
+```bash
+ai-teamlead test agent-flow \
+  --scenario run-happy-path \
+  --agent codex \
+  --mode live
+```
+
+Минимальные аргументы первой версии:
+
+- `--scenario <name>`
+- `--agent <stub|codex|claude>`
+- `--mode <stub|live>`
+
+Дополнительные аргументы:
+
+- `--keep-sandbox`
+- `--artifacts-dir <path>`
+- `--timeout-seconds <n>`
+- `--no-build`
+
+Правила:
+
+- `--mode stub` разрешает только `--agent stub`
+- `--mode live` разрешает `codex` и `claude`
+- итоговый exit code отражает verdict сценария
+
+### Scenario manifest
+
+Scenario manifest должен быть versioned и лежать внутри репозитория. Черновой
+формат:
+
+```yaml
+name: run-happy-path
+description: Run issue-analysis flow in isolated sandbox
+mode: stub
+agent: stub
+fixtures:
+  github_snapshot: basic-backlog.json
+  repo_state: clean
+commands:
+  - ai-teamlead run https://github.com/org/repo/issues/123
+assertions:
+  - type: exit_code
+    equals: 0
+  - type: issue_status
+    equals: Waiting for Plan Review
+  - type: file_exists
+    path: specs/issues/123/README.md
+```
+
+Scenario не должен содержать secrets. Он описывает:
+
+- какие fixtures нужны
+- какой agent profile используется
+- какие assertions обязательны
+- какой cleanup и artifact export ожидаются
+
+### Agent bridge
+
+Bridge должен быть явным и profile-based.
+
+Для каждого agent profile задаются:
+
+- `env_allowlist`
+- `file_mounts`
+- `binary_resolution`
+- `preflight_checks`
+
+Примеры допустимых данных bridge:
+
+- env vars вида `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `ANTHROPIC_API_KEY`
+- user-local config dirs или files для конкретного агента
+- repo-local `.claude/` и `.codex/`
+
+Недопустимо:
+
+- монтировать весь `$HOME` целиком
+- сохранять forwarded secrets в artifact bundle
+- делать implicit fallback на host filesystem вне allowlist
+
+### Stub agent
+
+`stub`-agent нужен не как отдельный shortcut, а как controlled implementation
+того же agent contract. Он должен:
+
+- стартовать через тот же launcher path
+- получать тот же prompt context
+- уметь выполнить заранее заданный сценарный outcome:
+  `plan-ready`, `needs-clarification`, `blocked`
+- вызывать те же внутренние команды завершения стадии
+
+## Технические решения
+
+- Канонический sandbox для MVP: Docker-based headless runtime.
+- Канонический `zellij` внутри sandbox: pinned version по ADR-0011.
+- Live и stub режимы используют один и тот же sandbox entrypoint.
+- Вердикт сценария считается по assertions, а не по одному exit code процесса.
+- Артефакты должны собираться вне зависимости от `passed` или `failed`.
+- Sandbox должен быть disposable по умолчанию; сохранение возможно только через
+  явный флаг `--keep-sandbox`.
+
+## Конфигурация
+
+Глобальные repo-local defaults логично хранить в `./.ai-teamlead/settings.yml`
+в новой секции `integration_tests.agent_flow`.
+
+Черновая схема:
+
+```yaml
+integration_tests:
+  agent_flow:
+    sandbox_runtime: docker
+    image: ai-teamlead-agent-flow-test:local
+    default_timeout_seconds: 900
+    artifacts_dir: ".git/.ai-teamlead/test-runs"
+    scenario_root: ".ai-teamlead/tests/agent-flow"
+    agent_profiles:
+      codex:
+        mode: live
+        env_allowlist:
+          - OPENAI_API_KEY
+          - OPENAI_BASE_URL
+        file_mounts: []
+      claude:
+        mode: live
+        env_allowlist:
+          - ANTHROPIC_API_KEY
+        file_mounts: []
+      stub:
+        mode: stub
+        env_allowlist: []
+        file_mounts: []
+```
+
+Правила:
+
+- без `integration_tests.agent_flow` entrypoint использует встроенные safe
+  defaults
+- secrets и значения токенов не хранятся в versioned YAML
+- в config хранятся только имена env vars, пути mounts и runtime defaults
+
+## Ограничения реализации
+
+- В первой версии допускается только один sandbox backend: Docker.
+- В первой версии допустим только Linux-oriented headless path.
+- В первой версии live assertions должны проверять orchestration и артефакты, а
+  не semantic quality generated текста.
+- Если agent CLI отсутствует или credentials не проброшены, сценарий должен
+  завершаться явным `preflight failed`, а не неявным timeout.
+
+## Связанные документы
+
+- [README.md](./README.md)
+- [01-what-we-build.md](./01-what-we-build.md)
+- [03-how-we-verify.md](./03-how-we-verify.md)
+- [../0003-agent-launch-orchestration/02-how-we-build.md](../0003-agent-launch-orchestration/02-how-we-build.md)

--- a/docs/features/0005-agent-flow-integration-testing/03-how-we-verify.md
+++ b/docs/features/0005-agent-flow-integration-testing/03-how-we-verify.md
@@ -1,0 +1,119 @@
+# Feature 0005: Как проверяем
+
+## Критерии корректности
+
+Решение считается корректным, если:
+
+- один локальный entrypoint поднимает sandbox и выполняет сценарий end-to-end
+- sandbox не использует host `zellij` session, tab или pane пользователя
+- `ai-teamlead` внутри sandbox запускается по обычному CLI path
+- `launch-agent.sh` и project-local flow prompt используются без test-only
+  bypass
+- `stub` и `live` режимы разделяют один и тот же orchestration path
+- agent credentials и config files попадают в sandbox только через явный
+  allowlist
+- forwarded secrets не сохраняются в artifact bundle и логах
+- по завершении прогона пользователь получает итоговый verdict и путь к
+  артефактам
+
+## Критерии готовности
+
+Feature считается готовой, если:
+
+- есть хотя бы один стабильный `stub`-сценарий для CI
+- есть хотя бы один локальный `live`-сценарий для реального агента
+- поддержаны как минимум два live-profile:
+  `codex` и `claude`, либо явно зафиксировано поэтапное включение с одним из
+  них в статусе MVP
+- результаты можно воспроизвести повторным запуском на той же машине
+- ошибки preflight, sandbox startup и assertion failure различимы по статусу и
+  диагностике
+
+## Инварианты
+
+- host-окружение пользователя не является execution surface для `zellij`-tests
+- versioned scenario manifest является источником истины для test intent
+- sandbox побочные эффекты не должны писать в рабочее дерево пользователя
+- live-режим использует реальные локальные agent settings, но только через
+  explicit bridge
+- тестовая платформа не подменяет `launch-agent.sh` отдельным искусственным
+  runner-скриптом
+- любой verdict должен сопровождаться artifact bundle
+
+## Сценарии проверки
+
+### Сценарий 1. `stub` happy path
+
+- запущен `ai-teamlead test agent-flow --scenario run-happy-path --agent stub --mode stub`
+- sandbox создается успешно
+- `ai-teamlead run` проходит обычный launcher path
+- `stub` завершает анализ как `plan-ready`
+- assertions подтверждают, что созданы analysis artifacts и итоговый статус
+  корректен
+
+### Сценарий 2. `stub` clarification path
+
+- сценарий моделирует `needs-clarification`
+- runner проверяет смену статуса и наличие диагностического сообщения
+
+### Сценарий 3. `live codex`
+
+- пользователь запускает локальный live-сценарий с `codex`
+- sandbox получает только разрешенные env vars и mounts для `codex`
+- агент стартует внутри sandbox и использует project-local flow
+- по завершении доступны логи и runtime artifacts
+
+### Сценарий 4. `live claude`
+
+- пользователь запускает локальный live-сценарий с `claude`
+- sandbox получает allowlisted настройки для `claude`
+- orchestration path совпадает с `codex`-сценарием до точки выбора agent
+  profile
+
+### Сценарий 5. Нет credentials
+
+- выбран `live`-режим
+- нужные env vars или config mounts отсутствуют
+- runner завершает прогон в статусе `preflight failed`
+- пользователь видит, какого именно bridge entry не хватило
+
+### Сценарий 6. Snapshot с локальными изменениями
+
+- в текущем working tree есть локальные изменения flow или launcher
+- snapshot включает эти изменения в sandbox
+- host repo остается неизменным после завершения теста
+
+### Сценарий 7. Падение assertions
+
+- orchestration path завершается, но expected assertions не выполняются
+- verdict = `failed`
+- artifact bundle сохраняется для ручного разбора
+
+### Сценарий 8. Сохранение sandbox по запросу
+
+- пользователь запускает сценарий с `--keep-sandbox`
+- после завершения runner не удаляет container/filesystem
+- в artifact metadata явно указан путь к сохраненному sandbox
+
+## Диагностика и наблюдаемость
+
+Минимально необходимо видеть:
+
+- `run_id`, имя сценария, выбранные `agent` и `mode`
+- effective image/tag sandbox-а
+- был ли использован `stub` или `live`
+- список forwarded env var names без значений
+- список mounted config paths
+- путь к workspace snapshot и artifact bundle
+- ключевые переходы состояний:
+  `snapshot_prepared`, `sandbox_ready`, `runtime_started`, `agent_running`,
+  `asserting`, итоговый verdict
+- stdout/stderr entrypoint-а и launcher-а
+- причину `preflight failed`, `failed` или `errored`
+
+## Связанные документы
+
+- [README.md](./README.md)
+- [01-what-we-build.md](./01-what-we-build.md)
+- [02-how-we-build.md](./02-how-we-build.md)
+- [../../adr/0011-use-zellij-main-release-in-ci.md](../../adr/0011-use-zellij-main-release-in-ci.md)

--- a/docs/features/0005-agent-flow-integration-testing/README.md
+++ b/docs/features/0005-agent-flow-integration-testing/README.md
@@ -1,0 +1,63 @@
+# Feature 0005: платформа integration-тестирования agent flow
+
+Статус: draft
+Владелец: владелец репозитория
+Последнее обновление: 2026-03-14
+
+## Контекст
+
+Проект уже фиксирует requirement на integration tests для `poll`, `run`,
+launcher-контракта и headless `zellij`, но пока не имеет отдельной платформы,
+которая локально поднимает полностью изолированный sandbox и прогоняет agent
+flow end-to-end.
+
+Новая feature описывает именно такую платформу:
+
+- с единым локальным entrypoint
+- с disposable sandbox, не использующим host `zellij`
+- с поддержкой реальных агентов `codex` и `claude`
+- с использованием project-local и user-local настроек подключения к LLM через
+  явный allowlist
+
+## Что строим
+
+- [01-what-we-build.md](./01-what-we-build.md)
+
+## Как строим
+
+- [02-how-we-build.md](./02-how-we-build.md)
+
+## Как проверяем
+
+- [03-how-we-verify.md](./03-how-we-verify.md)
+
+## Зависимости
+
+- [Feature 0001](../0001-ai-teamlead-cli/README.md) — основной CLI и runtime
+  orchestration
+- [Feature 0002](../0002-repo-init/README.md) — repo-local assets и
+  `settings.yml`
+- [Feature 0003](../0003-agent-launch-orchestration/README.md) — launcher path,
+  `zellij` и запуск агента
+
+## Связанные документы
+
+- [../../code-quality.md](../../code-quality.md)
+- [../../issue-analysis-flow.md](../../issue-analysis-flow.md)
+- [../../adr/0011-use-zellij-main-release-in-ci.md](../../adr/0011-use-zellij-main-release-in-ci.md)
+
+## Открытые вопросы
+
+- нужен ли отдельный CLI namespace `test` или достаточно подкоманды в
+  существующем verification path
+- хотим ли в MVP поддерживать live-run одновременно для `codex` и `claude` или
+  начать с одного real agent profile и одного stub profile
+- нужно ли отдельно ограничивать budget, timeout и максимальное число LLM
+  вызовов на сценарий
+
+## Журнал изменений
+
+### 2026-03-14
+
+- создан draft feature-документ для платформы integration-тестирования agent
+  flow


### PR DESCRIPTION
## Summary
- add feature 0005 docs for agent flow integration testing platform
- define scope, architecture, contracts, and verification criteria
- keep the work isolated from the in-progress feature branch

## Notes
- extracted from local main into a dedicated branch to avoid mixing docs work into main
