### PR TITLE
test(issue-analysis): verify full SDD artifact contract

### DIFF
--- a/tests/integration/helpers.sh
+++ b/tests/integration/helpers.sh
@@ -218,6 +218,7 @@ create_initialized_repo() {
     (
         cd "$repo_root"
         "$ai_teamlead_bin" init >/dev/null
+        sed -i '/^  layout: "compact"$/d' .ai-teamlead/settings.yml
         git add .ai-teamlead .claude .codex init.sh
         git commit -q -m "bootstrap ai-teamlead"
     )
@@ -344,9 +345,121 @@ fi
 
 mkdir -p "${AI_TEAMLEAD_ANALYSIS_ARTIFACTS_DIR:?}"
 cat > "${AI_TEAMLEAD_ANALYSIS_ARTIFACTS_DIR}/README.md" <<'DOC'
-# Test artifact
+# Issue 43: Test artifact
+
+Статус: draft
+Issue: https://github.com/dapi/example/issues/43
+
+## Артефакты
+
+- [01-what-we-build.md](./01-what-we-build.md)
+- [02-how-we-build.md](./02-how-we-build.md)
+- [03-how-we-verify.md](./03-how-we-verify.md)
 
 - generated from stub codex agent
+DOC
+
+cat > "${AI_TEAMLEAD_ANALYSIS_ARTIFACTS_DIR}/01-what-we-build.md" <<'DOC'
+# Что строим
+
+## Problem
+
+Нужен versioned SDD-комплект.
+
+## Who Is It For
+
+- repo owner
+
+## Outcome
+
+- создаются README.md, 01-what-we-build.md, 02-how-we-build.md, 03-how-we-verify.md
+
+## Scope
+
+- сформировать минимальный комплект
+
+## Non-Goals
+
+- implementation после анализа
+
+## Constraints And Assumptions
+
+- issue остается в GitHub Project
+
+## User Story
+
+Как владелец репозитория, я хочу получить SDD-комплект.
+
+## Use Cases
+
+- агент создает все четыре документа
+DOC
+
+cat > "${AI_TEAMLEAD_ANALYSIS_ARTIFACTS_DIR}/02-how-we-build.md" <<'DOC'
+# Как строим
+
+## Approach
+
+- используем staged prompts
+
+## Affected Areas
+
+- project-local flow
+
+## Interfaces And Data
+
+- AI_TEAMLEAD_ANALYSIS_ARTIFACTS_DIR
+
+## Configuration And Runtime Assumptions
+
+- launcher заранее создает каталог
+
+## Risks
+
+- агент может пропустить обязательный файл
+DOC
+
+cat > "${AI_TEAMLEAD_ANALYSIS_ARTIFACTS_DIR}/03-how-we-verify.md" <<'DOC'
+# Как проверяем
+
+## Acceptance Criteria
+
+- создан полный SDD-комплект
+
+## Ready Criteria
+
+- комплект пригоден для review
+
+## Invariants
+
+- есть минимум один документ на каждую ось
+
+## Test Plan
+
+- проверить четыре файла
+
+## Verification Checklist
+
+- README.md
+- 01-what-we-build.md
+- 02-how-we-build.md
+- 03-how-we-verify.md
+
+## Happy Path
+
+- feature issue создает User Story и Use Cases
+
+## Edge Cases
+
+- small issue не создает лишние документы
+
+## Failure Scenarios
+
+- создается только один README.md
+
+## Observability
+
+- видно analysis_artifacts_dir и issue URL
 DOC
 
 printf 'invoked\n' > "$OUT_DIR/codex.invoked"

--- a/tests/integration/test_00_init.sh
+++ b/tests/integration/test_00_init.sh
@@ -94,6 +94,39 @@ else
     ((FAIL++)) || true
 fi
 
+if grep -Fq 'README.md' "$FLOW_FILE" && \
+   grep -Fq '01-what-we-build.md' "$FLOW_FILE" && \
+   grep -Fq '02-how-we-build.md' "$FLOW_FILE" && \
+   grep -Fq '03-how-we-verify.md' "$FLOW_FILE"; then
+    echo "  PASS: init bootstraps minimal SDD artifact contract"
+    ((PASS++)) || true
+else
+    echo "  FAIL: init bootstraps minimal SDD artifact contract"
+    ((FAIL++)) || true
+fi
+
+if grep -Fq 'User Story' "$FLOW_WHAT_FILE" && \
+   grep -Fq 'Use Cases' "$FLOW_WHAT_FILE" && \
+   grep -Fq 'Observed Behavior' "$FLOW_WHAT_FILE" && \
+   grep -Fq 'Operational Goal' "$FLOW_WHAT_FILE"; then
+    echo "  PASS: init bootstraps rule-based task sections for what-we-build"
+    ((PASS++)) || true
+else
+    echo "  FAIL: init bootstraps rule-based task sections for what-we-build"
+    ((FAIL++)) || true
+fi
+
+if grep -Fq 'Acceptance Criteria' "$FLOW_VERIFY_FILE" && \
+   grep -Fq 'Happy Path' "$FLOW_VERIFY_FILE" && \
+   grep -Fq 'Regression Checks' "$FLOW_VERIFY_FILE" && \
+   grep -Fq 'Operational Validation' "$FLOW_VERIFY_FILE"; then
+    echo "  PASS: init bootstraps rule-based task sections for how-we-verify"
+    ((PASS++)) || true
+else
+    echo "  FAIL: init bootstraps rule-based task sections for how-we-verify"
+    ((FAIL++)) || true
+fi
+
 NO_GIT_DIR="$(mktemp -d /tmp/ai-teamlead-init-no-git-XXXXXX)"
 NO_GIT_OUTPUT_FILE="$(mktemp /tmp/ai-teamlead-init-no-git-output-XXXXXX)"
 

--- a/tests/integration/test_05_complete_stage_headless_zellij.sh
+++ b/tests/integration/test_05_complete_stage_headless_zellij.sh
@@ -88,10 +88,16 @@ fi
 WORKTREE_ROOT="${HOME}/worktrees/example/analysis/issue-43"
 ARTIFACTS_DIR="$WORKTREE_ROOT/specs/issues/43"
 ARTIFACT_README="$ARTIFACTS_DIR/README.md"
+ARTIFACT_WHAT="$ARTIFACTS_DIR/01-what-we-build.md"
+ARTIFACT_HOW="$ARTIFACTS_DIR/02-how-we-build.md"
+ARTIFACT_VERIFY="$ARTIFACTS_DIR/03-how-we-verify.md"
 
 wait_for_dir "$WORKTREE_ROOT" 30 || true
 wait_for_dir "$ARTIFACTS_DIR" 30 || true
 wait_for_file "$ARTIFACT_README" 30 || true
+wait_for_file "$ARTIFACT_WHAT" 30 || true
+wait_for_file "$ARTIFACT_HOW" 30 || true
+wait_for_file "$ARTIFACT_VERIFY" 30 || true
 wait_for_file "$STUB_OUT/complete-stage.exit_code" 30 || true
 
 PANE_ID="$(wait_for_json_field_not_value "$SESSION_MANIFEST" '.zellij.pane_id' 'pending' 30 || true)"
@@ -101,7 +107,10 @@ FLOW_STATUS="$(wait_for_json_field_not_value "$ISSUE_INDEX" '.last_known_flow_st
 assert_file_exists "$ISSUE_INDEX" "run created issue index for complete-stage flow"
 assert_file_exists "$SESSION_MANIFEST" "run created session manifest for complete-stage flow"
 assert_file_exists "$STUB_OUT/codex.invoked" "stub agent started inside zellij pane"
-assert_file_exists "$ARTIFACT_README" "stub agent created analysis artifact"
+assert_file_exists "$ARTIFACT_README" "stub agent created issue README"
+assert_file_exists "$ARTIFACT_WHAT" "stub agent created what-we-build artifact"
+assert_file_exists "$ARTIFACT_HOW" "stub agent created how-we-build artifact"
+assert_file_exists "$ARTIFACT_VERIFY" "stub agent created how-we-verify artifact"
 assert_eq "$(cat "$STUB_OUT/complete-stage.exit_code")" "0" "complete-stage exited successfully"
 assert_eq "$(cat "$STUB_OUT/issue_url")" "https://github.com/dapi/example/issues/43" "stub agent received issue URL"
 assert_eq "$(cat "$STUB_OUT/session_uuid")" "$SESSION_UUID" "stub agent received session UUID"
@@ -112,7 +121,13 @@ assert_eq "$(cat "$STUB_OUT/codex.cwd")" "$WORKTREE_ROOT" "stub agent ran inside
 assert_ne "$PANE_ID" "" "complete-stage flow captured zellij pane id"
 assert_eq "$SESSION_STATUS" "completed" "complete-stage marked session as completed"
 assert_eq "$FLOW_STATUS" "Waiting for Plan Review" "complete-stage updated issue flow status"
-assert_file_contains "$ARTIFACT_README" "generated from stub codex agent" "artifact content was written before complete-stage"
+assert_file_contains "$ARTIFACT_README" "generated from stub codex agent" "artifact README content was written before complete-stage"
+assert_file_contains "$ARTIFACT_README" "01-what-we-build.md" "artifact README links what-we-build doc"
+assert_file_contains "$ARTIFACT_WHAT" "## User Story" "feature artifact includes User Story section"
+assert_file_contains "$ARTIFACT_WHAT" "## Use Cases" "feature artifact includes Use Cases section"
+assert_file_contains "$ARTIFACT_HOW" "## Approach" "how-we-build artifact includes Approach section"
+assert_file_contains "$ARTIFACT_VERIFY" "## Acceptance Criteria" "how-we-verify artifact includes Acceptance Criteria section"
+assert_file_contains "$ARTIFACT_VERIFY" "## Verification Checklist" "how-we-verify artifact includes Verification Checklist section"
 assert_eq "$(git -C "$WORKTREE_ROOT" log -1 --pretty=%s)" "analysis(#43): stub analysis ready" "complete-stage committed analysis artifacts"
 assert_eq "$(git -C "$WORKTREE_ROOT" status --short)" "" "analysis worktree is clean after complete-stage commit"
 if git --git-dir="$REMOTE_REPO" show-ref --verify --quiet refs/heads/analysis/issue-43; then


### PR DESCRIPTION
Fixes #2

## What changed
- strengthen init integration assertions for minimal SDD artifact contract and rule-based sections
- make complete-stage stub agent produce the full four-file SDD kit
- keep headless launcher fixtures on the default session-create path so issue-analysis tests focus on SDD behavior rather than custom layout startup

## Verification
- cargo test
- mise run test-zellij